### PR TITLE
Fixes #8 consistency in request ID in example 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
           {
             "consentRequests": {
               "cookies": "Store and/or access cookies on your device.",
-              "ads_profiling": "Create a personalised ads profile."
+              "adsProfiling": "Create a personalised ads profile."
             }
           }
         </pre>


### PR DESCRIPTION
Note: Section 6.1 specifically mentions in a note that identifiers can
be any string following the valid format, which implies there are no
specified guidelines or rules regarding case (e.g. camealCase).